### PR TITLE
Fix the bot never connecting to Discord after the slash-create upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ before it connects to Discord, which takes a few minutes. Later starts reuse the
 | `MARKETBOT_CONFIG_VOLUME` | No | Directory holding `marketbot.ini`. Defaults to a Docker named volume. |
 | `MARKETBOT_DATA_VOLUME` | No | Where MarketBot keeps its database and caches. Defaults to a Docker named volume. |
 | `MARKETBOT_GIT_REVISION` | No | Image tag to run. Defaults to `latest`. |
-| `DEBUG` | No | Set to `marketbot*` or `*` for extra logging output. |
+| `DEBUG` | No | Set to `market-bot*` or `*` for extra logging output. Note the hyphen. |
 | `DISABLE_TRACKING_CYCLE` | No | Set to `true` to stop the periodic price-tracking checks. |
 
 Everything else, including the Discord credentials, lives in `config/marketbot.ini`.

--- a/src/services/slash-creator.service.ts
+++ b/src/services/slash-creator.service.ts
@@ -14,13 +14,13 @@ export class SlashCreatorService {
         this.creator.registerCommand(registerer(this.creator));
     }
 
-    public syncCommands(): Promise<unknown> {
-        return new Promise((resolve) => {
-            this.creator.once('synced', () => {
-                SlashCreatorService.debug('Commands synced');
-                resolve(undefined);
-            });
-            this.creator.syncCommands();
-        });
+    public async syncCommands(): Promise<void> {
+        // slash-create 5's syncCommands() was fire-and-forget and signalled completion
+        // by emitting "synced". Version 7 made it async and stopped emitting that event,
+        // although the event is still declared on the creator. Waiting for it therefore
+        // never resolves, and since this is awaited before client.login(), the bot would
+        // silently never connect to Discord and log nothing at all. Await the promise.
+        await this.creator.syncCommands();
+        SlashCreatorService.debug('Commands synced');
     }
 }


### PR DESCRIPTION
Fixes the bot never coming online after #32. It sits there with a healthy container, no errors, and no Discord connection.

## What happened

`slash-create` 5's `syncCommands()` was fire-and-forget. It kicked off the sync and signalled completion by emitting `synced`:

```js
syncCommands(opts) {
    this.syncCommandsAsync(opts)
        .then(() => this.emit('synced'))
        .catch((err) => this.emit('error', err));
    return this;
}
```

Version 7 made it `async` and returns a promise, and it no longer emits that event:

```js
async syncCommands(opts) {
    ...
    this.emit('debug', 'Finished syncing commands');
}
```

`synced` is still *declared* on the creator, so `once('synced', ...)` compiled fine and nothing looked wrong. But it never fires, so `SlashCreatorService.syncCommands()` never resolved. `activate()` awaits it immediately before `client.login()`, so the bot never connected.

It logged nothing because the failure is a promise that never settles rather than an error, and the `debug()` calls around it are silent unless `DEBUG` is set. The container stays up and healthy, so the deploy job's liveness check passes too. From the outside it looks exactly like a slow cache sync.

The fix is to await the promise that `syncCommands()` now returns. As a side effect a real sync failure propagates instead of hanging.

## Verified

Against a live `slash-create` 7 with a deliberately invalid token, comparing the two implementations directly:

```
master (once "synced")             -> HUNG (20s, never settled)
this branch (SlashCreatorService)  -> rejected: 401: Unauthorized
```

With a valid token the new path resolves and `client.login()` runs. Lint, the 20 unit tests, the build and `npm audit --omit=dev` are all clean.

## Also

The README documented `DEBUG=marketbot*`, but the namespace is `market-bot` (`Debug('market-bot')`), so that value matched nothing. Corrected to `market-bot*`. Worth knowing while diagnosing this class of problem, since `DEBUG=market-bot*` would have shown `Logging in...` never being reached.

## Why #32's testing missed it

The pre-merge container run used the config template, whose placeholder token made `syncGlobalCommands` reject with a 401. Because the old code never awaited `syncCommands()`, that surfaced as an unhandled rejection, which looked like the expected "invalid token" outcome and masked the fact that the promise had also hung. With a valid token there is no rejection at all, only the silent hang.
